### PR TITLE
feat: make AI-generated topics concise (1-2 words)

### DIFF
--- a/src/lib/ai-analyzer.ts
+++ b/src/lib/ai-analyzer.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 
 // Define Zod schema for AI response
 const ArticleAnalysisSchema = z.object({
-  topics: z.array(z.string()).max(5).describe('3-5 key topics from the article'),
+  topics: z.array(
+    z.string().refine(
+      (topic) => topic.trim().split(/\s+/).length <= 2,
+      { message: 'Each topic must be 1-2 words maximum' }
+    )
+  ).max(5).describe('3-5 concise topics (1-2 words each) from the article'),
   relevanceScore: z.number().min(0).max(1).describe('Relevance score between 0 and 1'),
   reasoning: z.string().max(500).describe('Brief explanation of relevance (1-2 sentences)'),
 });
@@ -30,7 +35,7 @@ export async function analyzeArticle(
   const hasInterests = userInterests.length > 0 || userGoals;
 
   const prompt = hasInterests
-    ? `Analyze this article and extract 3-5 key topics.
+    ? `Analyze this article and extract 3-5 key topics. Each topic MUST be concise, using only 1-2 words maximum.
 Calculate how relevant this article is to the user based on their interests and goals.
 
 User's Interests: ${userInterests.join(', ') || 'None'}
@@ -39,15 +44,25 @@ User's Goals: ${userGoals || 'None'}
 Article Content:
 ${truncatedContent}
 
+Topic Guidelines:
+- Use ONLY 1-2 words per topic (e.g., "React", "Machine Learning", "TypeScript", "API Design")
+- Be objective and specific
+- Avoid lengthy phrases or full sentences
+
 Relevance Score Guidelines:
 - 0.8-1.0: Highly relevant, directly related to interests
 - 0.5-0.79: Moderately relevant, tangentially related
 - 0.0-0.49: Less relevant, little connection`
-    : `Analyze this article and extract 3-5 key topics.
+    : `Analyze this article and extract 3-5 key topics. Each topic MUST be concise, using only 1-2 words maximum.
 Set relevance score to 0 since user hasn't specified interests yet.
 
 Article Content:
-${truncatedContent}`;
+${truncatedContent}
+
+Topic Guidelines:
+- Use ONLY 1-2 words per topic (e.g., "React", "Machine Learning", "TypeScript", "API Design")
+- Be objective and specific
+- Avoid lengthy phrases or full sentences`;
 
   try {
     const { object } = await generateObject({
@@ -67,17 +82,18 @@ ${truncatedContent}`;
       .toLowerCase()
       .replace(/[^\w\s]/g, ' ')
       .split(/\s+/)
-      .filter((w) => w.length > 5);
+      .filter((w) => w.length > 4); // Shorter minimum for better topic extraction
 
     const wordFreq: Record<string, number> = {};
     words.forEach((w) => {
       wordFreq[w] = (wordFreq[w] || 0) + 1;
     });
 
+    // Extract top 5 most frequent words as concise single-word topics
     const topWords = Object.entries(wordFreq)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 5)
-      .map(([word]) => word);
+      .map(([word]) => word.charAt(0).toUpperCase() + word.slice(1)); // Capitalize first letter
 
     return {
       topics: topWords,


### PR DESCRIPTION
Fixes #1

Updated the AI analyzer to generate concise, objective topics:
- Added explicit 1-2 word requirement to AI prompts
- Added Zod schema validation to enforce word limit
- Enhanced topic guidelines with clear examples
- Improved fallback mechanism to capitalize topics
- Updated schema description for clarity

This ensures tags are shorter and more scannable, making it easier
to quickly identify article subjects at a glance.