### PR TITLE
feat: transform dashboard into inbox-style interface

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
 import { SaveArticleForm } from "@/components/dashboard/save-article-form";
 import { SavedItemsList } from "@/components/dashboard/saved-items-list";
+import { GroupedItemsDisplay } from "@/components/dashboard/grouped-items-display";
 import { EmptyState } from "@/components/dashboard/empty-state";
 import { FilterTabs } from "@/components/dashboard/filter-tabs";
 import { Button } from "@/components/ui/button";
@@ -153,48 +154,11 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
         {/* Saved Articles or Empty State */}
         {savedItems.length > 0 ? (
           filter === 'all' && groupedItems ? (
-            <div className="space-y-12">
-              {/* Unread Section */}
-              {groupedItems.unread.length > 0 && (
-                <div className="space-y-6">
-                  <div className="flex items-center gap-3">
-                    <h2 className="text-2xl font-semibold bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
-                      Up Next
-                    </h2>
-                    <span className="text-lg text-muted-foreground">
-                      {groupedItems.unread.length}
-                    </span>
-                  </div>
-                  <SavedItemsList items={groupedItems.unread} />
-                </div>
-              )}
-
-              {/* Read Section */}
-              {groupedItems.read.length > 0 && (
-                <div className="space-y-6">
-                  <div className="flex items-center gap-3">
-                    <h2 className="text-2xl font-semibold">Read</h2>
-                    <span className="text-lg text-muted-foreground">
-                      {groupedItems.read.length}
-                    </span>
-                  </div>
-                  <SavedItemsList items={groupedItems.read} />
-                </div>
-              )}
-
-              {/* Archived Section */}
-              {groupedItems.archived.length > 0 && (
-                <div className="space-y-6">
-                  <div className="flex items-center gap-3">
-                    <h2 className="text-2xl font-semibold">Archived</h2>
-                    <span className="text-lg text-muted-foreground">
-                      {groupedItems.archived.length}
-                    </span>
-                  </div>
-                  <SavedItemsList items={groupedItems.archived} />
-                </div>
-              )}
-            </div>
+            <GroupedItemsDisplay
+              unread={groupedItems.unread}
+              read={groupedItems.read}
+              archived={groupedItems.archived}
+            />
           ) : (
             <SavedItemsList items={savedItems} />
           )

--- a/src/components/dashboard/grouped-items-display.tsx
+++ b/src/components/dashboard/grouped-items-display.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+import { SavedItemsList } from './saved-items-list';
+import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SavedItem {
+  id: string;
+  url: string;
+  title: string;
+  estimatedTime: number;
+  savedAt: Date;
+  topics: string[];
+  relevanceScore: number;
+  reasoning: string;
+  readAt: Date | null;
+  archivedAt: Date | null;
+}
+
+interface GroupedItemsDisplayProps {
+  unread: SavedItem[];
+  read: SavedItem[];
+  archived: SavedItem[];
+}
+
+/**
+ * Client component that displays grouped items with collapsible sections
+ * for read and archived items (inbox-style)
+ */
+export function GroupedItemsDisplay({ unread, read, archived }: GroupedItemsDisplayProps) {
+  const [showRead, setShowRead] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  return (
+    <div className="space-y-12">
+      {/* Unread Section - Always visible */}
+      {unread.length > 0 && (
+        <div className="space-y-6">
+          <div className="flex items-center gap-3">
+            <h2 className="text-2xl font-semibold bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+              Up Next
+            </h2>
+            <span className="text-lg text-muted-foreground">
+              {unread.length}
+            </span>
+          </div>
+          <SavedItemsList items={unread} />
+        </div>
+      )}
+
+      {/* Read Section - Collapsible */}
+      {read.length > 0 && (
+        <div className="space-y-6">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowRead(!showRead)}
+              className="flex items-center gap-2 -ml-2 hover:bg-transparent"
+            >
+              {showRead ? (
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-5 w-5 text-muted-foreground" />
+              )}
+              <h2 className="text-2xl font-semibold">Read</h2>
+            </Button>
+            <span className="text-lg text-muted-foreground">
+              {read.length}
+            </span>
+          </div>
+
+          {showRead && <SavedItemsList items={read} />}
+
+          {!showRead && (
+            <div className="text-sm text-muted-foreground pl-2">
+              {read.length} read article{read.length !== 1 ? 's' : ''} hidden · Click to show
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Archived Section - Collapsible */}
+      {archived.length > 0 && (
+        <div className="space-y-6">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowArchived(!showArchived)}
+              className="flex items-center gap-2 -ml-2 hover:bg-transparent"
+            >
+              {showArchived ? (
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-5 w-5 text-muted-foreground" />
+              )}
+              <h2 className="text-2xl font-semibold">Archived</h2>
+            </Button>
+            <span className="text-lg text-muted-foreground">
+              {archived.length}
+            </span>
+          </div>
+
+          {showArchived && <SavedItemsList items={archived} />}
+
+          {!showArchived && (
+            <div className="text-sm text-muted-foreground pl-2">
+              {archived.length} archived article{archived.length !== 1 ? 's' : ''} hidden · Click to show
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #3

Implemented collapsible sections for read and archived articles:
- Created GroupedItemsDisplay component with toggle functionality
- Read and archived sections are hidden by default
- Added chevron icons to indicate expand/collapse state
- Display count of hidden items with helpful hint text
- Unread items ("Up Next") always visible for focus
- Click section headers to reveal hidden articles

This creates a cleaner, more focused inbox-style experience by reducing visual clutter and helping users focus on unread content.